### PR TITLE
Align PR template to commit_groups

### DIFF
--- a/auto_semver_config.yml
+++ b/auto_semver_config.yml
@@ -116,7 +116,7 @@ pull_request:
     **Version:** {{version}}  
     **Date:** {{date}}
     
-    {% for group in grouped_messages -%}
+    {% for group in commit_groups -%}
     {% if group.commits -%}
     ## {{ group.title }}
     

--- a/tests/pr/test_github_builder.py
+++ b/tests/pr/test_github_builder.py
@@ -1,5 +1,6 @@
 """Unit tests for GitHubPRBuilder."""
 
+from auto_semver.config._models._commit_group import Commit, CommitGroup
 from auto_semver.pr.github_builder import GitHubPRBuilder, GitHubPRTemplateVariables
 
 
@@ -43,6 +44,46 @@ def test_build_body() -> None:
     )
     expected = "This PR releases version 1.2.3 on 2025-10-08.\nCommits: fix: bug, feat: new"
     assert builder.body == expected
+
+
+def test_build_body_with_commit_groups() -> None:
+    """Test building PR body with commit_groups variable."""
+    # Create test commit groups
+    commit1 = Commit(title="add new feature", body=None)
+    commit2 = Commit(title="fix bug", body=None)
+    group1 = CommitGroup(title="Features", commits=[commit1], priority=1)
+    group2 = CommitGroup(title="Bug Fixes", commits=[commit2], priority=2)
+    
+    data = GitHubPRTemplateVariables(
+        version="1.2.3",
+        previous_version="1.2.2",
+        commit_groups=[group1, group2],
+        breaking_changes=[],
+        author="",
+        repository="",
+        date="2025-10-22",
+        branch="",
+        base_branch="",
+        labels=None,
+        groups=[group1, group2],
+    )
+    
+    # Use template similar to config file
+    body_template = """## Release {{ version }}
+{% for group in commit_groups -%}
+### {{ group.title }}
+{% for commit in group.commits -%}
+- {{ commit.title }}
+{% endfor -%}
+{% endfor -%}"""
+    
+    builder = GitHubPRBuilder(data=data, body_template=body_template)
+    
+    assert "## Release 1.2.3" in builder.body
+    assert "### Features" in builder.body
+    assert "### Bug Fixes" in builder.body
+    assert "- add new feature" in builder.body
+    assert "- fix bug" in builder.body
 
 
 def test_build_labels() -> None:


### PR DESCRIPTION
Templates:

- Update pull_request.body to iterate commit_groups

- Keep changelog template compatible (legacy alias supported)

Testing:

- Add PR builder test to validate commit_groups rendering

Behavior:

- Rely on config variable names; no code aliases required