### PR TITLE
Enhance commit grouping with bullet point extraction

### DIFF
--- a/auto_semver_config.yml
+++ b/auto_semver_config.yml
@@ -118,17 +118,11 @@ pull_request:
     
     {% for group in commit_groups -%}
     {% if group.commits -%}
-    ## {{ group.title }}
-    
+    ### {{ group.title }}
     {% for commit in group.commits -%}
-    {% if commit.body -%}
-    ### {{ commit.title }}
-    {{ commit.body }}
-    {% else -%}
-    - {{ commit.message }}
-    {% endif -%}
-    
+    - {{ commit.title }}
     {% endfor -%}
+    
     {% endif -%}
     {% endfor -%}
 
@@ -141,16 +135,10 @@ changelog:
     {% for group in grouped_messages -%}
     {% if group.commits -%}
     ### {{ group.title }}
-    
     {% for commit in group.commits -%}
-    {% if commit.body -%}
-    **{{ commit.title }}**  
-    {{ commit.body }}
-    {% else -%}
-    - {{ commit.message }}
-    {% endif -%}
-    
+    - {{ commit.title }}
     {% endfor -%}
+    
     {% endif -%}
     {% endfor -%}
 

--- a/src/auto_semver/config/_models/_commit_group.py
+++ b/src/auto_semver/config/_models/_commit_group.py
@@ -159,6 +159,9 @@ class CommitGroupConfig(BaseModel):
 
         Takes a list of raw commit messages and groups them according to the
         configured patterns, returning structured data for template rendering.
+        
+        For commits with multi-line bodies containing bullet points, extracts
+        each bullet point as a separate commit item to categorize individually.
 
         Args:
             messages: List of raw commit messages from git.
@@ -179,26 +182,29 @@ class CommitGroupConfig(BaseModel):
         # Sort groups by priority (lower numbers first)
         sorted_groups = sorted(commit_groups, key=lambda g: g.priority)
 
-        # Group messages
+        # Extract individual items from commit messages (including body bullet points)
+        individual_items = CommitGroupConfig._extract_individual_items(messages)
+
+        # Group individual items
         groups: dict[str, CommitGroup] = {}
         unmatched: list[str] = []
 
-        for message in messages:
+        for item in individual_items:
             matched = False
             for group in sorted_groups:
-                if CommitGroupConfig._message_matches(message, group.patterns):
+                if CommitGroupConfig._message_matches(item, group.patterns):
                     if group.title not in groups:
                         groups[group.title] = CommitGroup(
                             title=group.title,
                             commits=[],
                             priority=group.priority,
                         )
-                    groups[group.title].commits.append(CommitGroupConfig._parse_commit(message))
+                    groups[group.title].commits.append(CommitGroupConfig._parse_commit(item))
                     matched = True
                     break
 
             if not matched:
-                unmatched.append(message)
+                unmatched.append(item)
 
         # Handle unmatched messages
         if unmatched:
@@ -212,6 +218,36 @@ class CommitGroupConfig(BaseModel):
 
         # Sort by priority (lower numbers first)
         return sorted(result, key=lambda g: g.priority)
+
+    @staticmethod
+    def _extract_individual_items(messages: list[str]) -> list[str]:
+        """
+        Extract individual items from commit messages.
+        
+        For commits with bullet points in the body, extract each bullet as a separate item.
+        Returns a list of individual commit lines/items to be categorized.
+        """
+        items = []
+        for message in messages:
+            lines = message.strip().split("\n")
+            
+            # Check if there are bullet points in the body
+            has_bullets = any(line.strip().startswith(("-", "*", "•")) for line in lines[1:])
+            
+            if has_bullets:
+                # Extract each bullet point as a separate item
+                for line in lines[1:]:
+                    stripped_line = line.strip()
+                    if stripped_line.startswith(("-", "*", "•")):
+                        # Remove bullet marker and clean up
+                        clean_line = stripped_line.lstrip("-*•").strip()
+                        if clean_line:
+                            items.append(clean_line)
+            else:
+                # No bullets, use the full commit message
+                items.append(message)
+        
+        return items
 
     @staticmethod
     def _message_matches(message: str, patterns: list[str]) -> bool:

--- a/tests/auto_semver/utils/test_commit_bullet_extraction.py
+++ b/tests/auto_semver/utils/test_commit_bullet_extraction.py
@@ -1,0 +1,186 @@
+"""Test commit bullet point extraction for grouping."""
+
+from auto_semver.config._models._commit_group import CommitGroupConfig
+
+
+def test_extract_individual_items_with_bullets() -> None:
+    """Test extraction of individual bullet points from commit bodies."""
+    commit_with_bullets = """Add comprehensive E2E and integration test suite
+
+Test Infrastructure:
+- Add modular fixtures for isolated testing
+- Create 17 comprehensive E2E/integration tests
+- Implement test_e2e_workflows.py with 6 workflow scenarios
+
+Template System Improvements:
+- Extract shared template utilities to templates/utils.py
+- Add comprehensive template function registry
+- Implement custom Jinja2 filters for PR/changelog generation"""
+
+    items = CommitGroupConfig._extract_individual_items([commit_with_bullets])
+    
+    # Should extract 6 bullet points
+    assert len(items) == 6
+    assert "Add modular fixtures for isolated testing" in items
+    assert "Create 17 comprehensive E2E/integration tests" in items
+    assert "Implement test_e2e_workflows.py with 6 workflow scenarios" in items
+    assert "Extract shared template utilities to templates/utils.py" in items
+    assert "Add comprehensive template function registry" in items
+    assert "Implement custom Jinja2 filters for PR/changelog generation" in items
+
+
+def test_extract_individual_items_without_bullets() -> None:
+    """Test that commits without bullets are kept as-is."""
+    simple_commit = "feat: add user authentication system"
+    
+    items = CommitGroupConfig._extract_individual_items([simple_commit])
+    
+    assert len(items) == 1
+    assert items[0] == simple_commit
+
+
+def test_extract_individual_items_mixed() -> None:
+    """Test extraction with mix of simple and multi-line commits."""
+    messages = [
+        "fix: resolve login bug",
+        """Refactor configuration system
+
+Core Changes:
+- Split monolithic config/data.py into focused modules
+- Create centralized Jinja2 template engine
+- Add typed template variable dataclasses""",
+        "docs: update README",
+    ]
+    
+    items = CommitGroupConfig._extract_individual_items(messages)
+    
+    # Should have: 1 simple + 3 bullets + 1 simple = 5 items
+    assert len(items) == 5
+    assert "fix: resolve login bug" in items
+    assert "Split monolithic config/data.py into focused modules" in items
+    assert "Create centralized Jinja2 template engine" in items
+    assert "Add typed template variable dataclasses" in items
+    assert "docs: update README" in items
+
+
+def test_group_messages_with_bullet_extraction() -> None:
+    """Test that bullet points are categorized into correct groups."""
+    messages = [
+        """Add comprehensive test suite
+
+Testing Infrastructure:
+- Add modular fixtures for isolated testing
+- Create 17 comprehensive E2E/integration tests
+
+Features:
+- Add console script entry point for Docker
+- Enhance changelog template formatting"""
+    ]
+    
+    commit_groups = [
+        CommitGroupConfig(title="✨ Features", patterns=["^Add ", "^Enhance "], priority=1),
+        CommitGroupConfig(title="🧪 Testing", patterns=["^Create ", "fixtures"], priority=2),
+    ]
+    
+    grouped = CommitGroupConfig.group_messages(messages, commit_groups)
+    
+    # Should have 2 groups
+    assert len(grouped) == 2
+    
+    # Check Features group
+    features = next(g for g in grouped if g.title == "✨ Features")
+    assert len(features.commits) == 3  # "Add modular...", "Add console...", "Enhance..."
+    titles = [c.title for c in features.commits]
+    assert "Add modular fixtures for isolated testing" in titles
+    assert "Add console script entry point for Docker" in titles
+    assert "Enhance changelog template formatting" in titles
+    
+    # Check Testing group  
+    testing = next(g for g in grouped if g.title == "🧪 Testing")
+    assert len(testing.commits) == 1  # "Create 17..."
+    assert "Create 17 comprehensive E2E/integration tests" in testing.commits[0].title
+
+
+def test_group_messages_simple_commits_without_body() -> None:
+    """Test that simple commits without bodies are categorized correctly."""
+    messages = [
+        "feat: add user authentication",
+        "fix: resolve login bug",
+        "docs: update README",
+        "Add console script entry point",
+    ]
+    
+    commit_groups = [
+        CommitGroupConfig(title="✨ Features", patterns=["^feat:", "^Add "], priority=1),
+        CommitGroupConfig(title="🐛 Bug Fixes", patterns=["^fix:"], priority=2),
+        CommitGroupConfig(title="📚 Documentation", patterns=["^docs:"], priority=3),
+    ]
+    
+    grouped = CommitGroupConfig.group_messages(messages, commit_groups)
+    
+    # Should have 3 groups
+    assert len(grouped) == 3
+    
+    # Check Features group - should have 2 items
+    features = next(g for g in grouped if g.title == "✨ Features")
+    assert len(features.commits) == 2
+    titles = [c.title for c in features.commits]
+    assert "add user authentication" in titles  # Cleaned from "feat: ..."
+    assert "Add console script entry point" in titles
+    
+    # Check Bug Fixes group - should have 1 item
+    fixes = next(g for g in grouped if g.title == "🐛 Bug Fixes")
+    assert len(fixes.commits) == 1
+    assert "resolve login bug" in fixes.commits[0].title
+    
+    # Check Documentation group - should have 1 item
+    docs = next(g for g in grouped if g.title == "📚 Documentation")
+    assert len(docs.commits) == 1
+    assert "update README" in docs.commits[0].title
+
+
+def test_group_messages_mixed_simple_and_bulleted() -> None:
+    """Test mixed scenario with simple commits and commits with bullet points."""
+    messages = [
+        "fix: resolve login timeout issue",
+        """Refactor configuration system
+
+Core Changes:
+- Split monolithic config into focused modules
+- Create centralized template engine
+- Add typed variable dataclasses
+
+Testing:
+- Add comprehensive test suite
+- Implement fixture-based testing""",
+        "docs: update installation guide",
+    ]
+    
+    commit_groups = [
+        CommitGroupConfig(title="♻️ Refactoring", patterns=["^Refactor", "^Split ", "^Create "], priority=1),
+        CommitGroupConfig(title="🐛 Bug Fixes", patterns=["^fix:"], priority=2),
+        CommitGroupConfig(title="🧪 Testing", patterns=["^Add comprehensive", "^Implement "], priority=3),
+        CommitGroupConfig(title="📚 Documentation", patterns=["^docs:"], priority=4),
+        CommitGroupConfig(title="📝 Other", patterns=["^Add typed"], priority=5),
+    ]
+    
+    grouped = CommitGroupConfig.group_messages(messages, commit_groups)
+    
+    # Check that simple commits are preserved
+    fixes = next(g for g in grouped if g.title == "🐛 Bug Fixes")
+    assert len(fixes.commits) == 1
+    assert "resolve login timeout issue" in fixes.commits[0].title
+    
+    docs = next(g for g in grouped if g.title == "📚 Documentation")
+    assert len(docs.commits) == 1
+    assert "update installation guide" in docs.commits[0].title
+    
+    # Check that bullets were extracted and categorized
+    refactoring = next(g for g in grouped if g.title == "♻️ Refactoring")
+    assert len(refactoring.commits) == 2  # "Split..." and "Create..."
+    
+    testing = next(g for g in grouped if g.title == "🧪 Testing")
+    assert len(testing.commits) == 2  # "Add comprehensive..." and "Implement..."
+    
+    other = next(g for g in grouped if g.title == "📝 Other")
+    assert len(other.commits) == 1  # "Add typed..."

--- a/tests/pr/test_github_builder.py
+++ b/tests/pr/test_github_builder.py
@@ -51,8 +51,8 @@ def test_build_body_with_commit_groups() -> None:
     # Create test commit groups
     commit1 = Commit(title="add new feature", body=None)
     commit2 = Commit(title="fix bug", body=None)
-    group1 = CommitGroup(title="Features", commits=[commit1], priority=1)
-    group2 = CommitGroup(title="Bug Fixes", commits=[commit2], priority=2)
+    group1 = CommitGroup(title="✨ Features & Enhancements", commits=[commit1], priority=1)
+    group2 = CommitGroup(title="🐛 Bug Fixes & Resolutions", commits=[commit2], priority=2)
     
     data = GitHubPRTemplateVariables(
         version="1.2.3",
@@ -68,20 +68,28 @@ def test_build_body_with_commit_groups() -> None:
         groups=[group1, group2],
     )
     
-    # Use template similar to config file
-    body_template = """## Release {{ version }}
+    # Use template matching the config file format
+    body_template = """## 🚀 Release Notes
+**Version:** {{ version }}  
+**Date:** {{ date }}
+
 {% for group in commit_groups -%}
+{% if group.commits -%}
 ### {{ group.title }}
 {% for commit in group.commits -%}
 - {{ commit.title }}
 {% endfor -%}
+
+{% endif -%}
 {% endfor -%}"""
     
     builder = GitHubPRBuilder(data=data, body_template=body_template)
     
-    assert "## Release 1.2.3" in builder.body
-    assert "### Features" in builder.body
-    assert "### Bug Fixes" in builder.body
+    # Verify structured output with grouped sections
+    assert "## 🚀 Release Notes" in builder.body
+    assert "**Version:** 1.2.3" in builder.body
+    assert "### ✨ Features & Enhancements" in builder.body
+    assert "### 🐛 Bug Fixes & Resolutions" in builder.body
     assert "- add new feature" in builder.body
     assert "- fix bug" in builder.body
 


### PR DESCRIPTION
Core Changes:
- Add bullet point extraction logic to parse structured commit bodies
- Extract individual items from commit body bullets for granular categorization
- Simplify PR and changelog templates to display clean grouped commits
- Update template variable names for consistency (commit_groups)

Implementation Details:
- Add _extract_individual_items() method to parse bullet points
- Detect bullets with -, *, or • markers in commit bodies
- Preserve simple commits without bullets as single items
- Each bullet categorized independently by pattern matching

Template Improvements:
- Remove verbose body rendering from PR/changelog templates
- Display only commit.title in clean bullet lists
- Maintain group headers with emoji icons and priorities
- Support both commit_groups and grouped_messages variables

Testing:
- Add 6 comprehensive tests for bullet extraction scenarios
- Test simple commits, bulleted commits, and mixed scenarios
- Verify pattern matching works per-bullet not per-commit
- Validate backward compatibility with title-only commits

Benefits:
- Supports Git best practices for structured commit bodies
- Clean, organized release notes from detailed commit messages
- Accurate grouping at item level instead of commit level
- Maintains flexibility for future template customization