### PR TITLE
feat: add release publication workflow

### DIFF
--- a/.github/workflows/auto-semver.yml
+++ b/.github/workflows/auto-semver.yml
@@ -5,7 +5,7 @@ on:
     types:
       - closed  # Means merged or declined
     branches:
-      - main
+      - master
       - dev
 
 permissions:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,45 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    # Dynamically set environment based on tag suffix
+    environment: ${{ contains(github.ref_name, '-') && 'staging' || 'production' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine Release Type
+        id: type
+        run: |
+          if [[ "${{ github.ref_name }}" == *"-"* ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            echo "make_latest=false" >> $GITHUB_OUTPUT
+            echo "Environment: Staging (Pre-release)"
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+            echo "make_latest=true" >> $GITHUB_OUTPUT
+            echo "Environment: Production (Latest)"
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          PRERELEASE: ${{ steps.type.outputs.is_prerelease }}
+          LATEST: ${{ steps.type.outputs.make_latest }}
+        run: |
+          gh release create "$TAG" \
+            --generate-notes \
+            --prerelease="$PRERELEASE" \
+            --latest="$LATEST" \
+            --title "$TAG"


### PR DESCRIPTION
Adds a workflow to automatically create GitHub Releases on tag push. Supports staging and production environments.