### PR TITLE
fix: refactor lock version retrieval logic

### DIFF
--- a/src/auto_semver/cli/bump.py
+++ b/src/auto_semver/cli/bump.py
@@ -122,7 +122,7 @@ def run(*, gitops: GitOps, event: GitHubEvent, config: Config, github_token: str
     logger.info(f"Branch name: {current_branch}")
 
     # Get current version first to check for tag promotion
-    version = gitops.get_highest_release_lock_version_for_target(target_branch)
+    version = gitops.get_lock_version_from_branch(target_branch)
 
     if not version:
         try:

--- a/src/auto_semver/cli/promote.py
+++ b/src/auto_semver/cli/promote.py
@@ -54,7 +54,7 @@ def run(
 
     # Get the latest tag/version from the source branch
     try:
-        version = gitops.get_highest_release_lock_version_for_target(from_branch)
+        version = gitops.get_lock_version_from_branch(branch_name=from_branch)
         if not version:
             raise ValueError(
                 f"No version found for branch '{from_branch}'. Ensure the branch is tagged."

--- a/src/auto_semver/git/ops.py
+++ b/src/auto_semver/git/ops.py
@@ -682,65 +682,40 @@ class GitOps:
 
             raise RuntimeError(f"Failed to fetch recent commits: {err}") from err
 
-    def get_highest_release_lock_version_for_target(
-        self, target_branch: str | None = None, remote_name: str = "origin"
+    def get_lock_version_from_branch(
+        self,
+        branch_name: str,
+        remote_name: str = "origin",
     ) -> Version | None:
         """
-        Scan all release/* branches, for lockfile.
+        Get the version from the lockfile on a specific branch.
 
         Args:
-            target_branch (str): The target branch to check against.
+            branch_name (str): The branch to check.
             remote_name (str): The name of the remote to check.
 
         Returns:
-            The highest Version object found, or None if none found.
+            The Version object found, or None if none found.
 
         """
-        highest: Version | None = None
-        remote: Remote = self.repo.remote(name=remote_name)
-
         try:
-            logger.info("Fetching all remote branches...")
-            remote.fetch(prune=True)
+            logger.info(f"Fetching branch '{branch_name}' from remote '{remote_name}'...")
+            self.repo.git.fetch(remote_name, branch_name)
 
-            for ref in remote.refs:
-                if (
-                    not ref.name.startswith("origin/release/")
-                    and ref.name != f"origin/{target_branch}"
-                ):
-                    logger.debug(f"Skipping branch {ref.name}.")
-                    continue
+            full_branch_ref = f"{remote_name}/{branch_name}"
+            logger.debug(f"Checking branch for lockfile: {full_branch_ref}")
 
-                branch_name = ref.name
-                short_branch_name = branch_name.removeprefix("origin/")
-                logger.debug(f"Checking branch for lockfile: {short_branch_name}")
-
-                try:
-                    blob = self.repo.git.show(f"{branch_name}:{SemverLock.path}")
-                    lock = SemverLock.from_dict(yaml.safe_load(blob))
-                    logger.debug(f"Loaded lockfile from {short_branch_name}: {lock}")
-
-                    if target_branch and lock.target_branch != target_branch:
-                        logger.debug(
-                            f"Skipping lockfile on {short_branch_name} for target branch {target_branch}."
-                        )
-                        continue
-
-                    logger.debug(f"Found lock version {lock.version} on {short_branch_name}")
-
-                    if highest is None:
-                        highest = lock.version
-                        logger.debug(f"First lockfile found: {highest}")
-                    else:
-                        highest = max(highest, lock.version)
-                        logger.debug(f"New highest version: {highest}")
-                except Exception as err:
-                    logger.warning(f"No lockfile in {short_branch_name}: {err}")
-
-            return highest
+            try:
+                blob = self.repo.git.show(f"{full_branch_ref}:{SemverLock.path}")
+                lock = SemverLock.from_dict(yaml.safe_load(blob))
+                logger.debug(f"Loaded lockfile from {branch_name}: {lock}")
+                return lock.version
+            except Exception as err:
+                logger.warning(f"No lockfile in {branch_name}: {err}")
+                return None
 
         except Exception as err:
-            logger.error(f"Failed to scan remote release branches: {err}")
+            logger.error(f"Failed to get lock version from branch {branch_name}: {err}")
             return None
 
     def _filter_release_commits(self, messages: list[str], config: Config) -> list[str]:

--- a/tests/auto_semver/cli/test_bump.py
+++ b/tests/auto_semver/cli/test_bump.py
@@ -37,7 +37,7 @@ class TestBump:
         """Create a mock GitOps object."""
         mock = mocker.Mock(spec=GitOps)
         # Set up some default behaviors
-        mock.get_highest_release_lock_version_for_target.return_value = None
+        mock.get_lock_version_from_branch.return_value = None
         mock.get_recent_commits.return_value = ["feat: add new feature", "fix: bug fix"]
         return mock
 
@@ -135,7 +135,7 @@ class TestBump:
         """Test bump with existing version."""
         # Set up mock to return an existing version
         existing_version = Version.parse("0.9.0")
-        mock_gitops.get_highest_release_lock_version_for_target.return_value = existing_version
+        mock_gitops.get_lock_version_from_branch.return_value = existing_version
 
         # Mock datetime.now for consistent testing
         mock_now = datetime.datetime(2023, 1, 1, 12, 0, 0)
@@ -150,7 +150,7 @@ class TestBump:
 
         # Verify version was bumped from the existing version
         # The SemverLock constructor should have been used
-        mock_gitops.get_highest_release_lock_version_for_target.assert_called_once_with("main")
+        mock_gitops.get_lock_version_from_branch.assert_called_once_with("main")
 
         # Verify PR was created
         mock_gitops.create_pr.assert_called_once()

--- a/tests/auto_semver/cli/test_bump_promotion.py
+++ b/tests/auto_semver/cli/test_bump_promotion.py
@@ -185,7 +185,7 @@ class TestPromotionWorkflow:
     def mock_gitops(self, mocker: MockerFixture) -> Any:
         """Create a mock GitOps object."""
         mock = mocker.Mock(spec=GitOps)
-        mock.get_highest_release_lock_version_for_target.return_value = None
+        mock.get_lock_version_from_branch.return_value = None
         mock.get_recent_commits.return_value = ["feat: promotion feature"]
         return mock
 

--- a/tests/auto_semver/git/test_ops.py
+++ b/tests/auto_semver/git/test_ops.py
@@ -361,58 +361,30 @@ class TestGitOps:
         mock_repo.iter_commits.assert_called_once_with("abc123..HEAD")
 
     @pytest.mark.unit
-    def test_get_highest_release_lock_version_for_target(self, mocker: MockerFixture) -> None:
-        """Test getting the highest release lock version with get_highest_release_lock_version_for_target."""
-        # Create mock repo and remote
+    def test_get_lock_version_from_branch(self, mocker: MockerFixture) -> None:
+        """Test getting the lock version from a specific branch."""
+        # Create mock repo
         mock_repo = mocker.MagicMock()
-        mock_remote = mocker.MagicMock()
-        mock_repo.remote.return_value = mock_remote
-
-        # Create mock refs
-        mock_ref1 = mocker.MagicMock()
-        mock_ref1.name = "origin/release/v1.0.0"
-        mock_ref2 = mocker.MagicMock()
-        mock_ref2.name = "origin/release/v1.1.0"
-        mock_ref3 = mocker.MagicMock()
-        mock_ref3.name = "origin/develop"  # Should be skipped
-        mock_remote.refs = [mock_ref1, mock_ref2, mock_ref3]
-
-        # Set up mock lock files - must include all required fields
-        lock1 = {"version": "1.0.0", "target_branch": "main", "source_branch": "develop"}
-        lock2 = {"version": "1.1.0", "target_branch": "main", "source_branch": "develop"}
 
         # Patch functions
         mocker.patch("auto_semver.git.ops.Repo", return_value=mock_repo)
-        mocker.patch("auto_semver.git.ops.yaml.safe_load", side_effect=[lock1, lock2])
-        # Create a mock Version object to return in SemverLock
+
+        # Mock lock file data
+        lock_data = {"version": "1.2.3", "target_branch": "main", "source_branch": "develop"}
+        mocker.patch("auto_semver.git.ops.yaml.safe_load", return_value=lock_data)
+
+        # Mock SemverLock
         mock_version = mocker.MagicMock(spec=Version)
-        mock_version.__str__.return_value = "1.1.0"
-
-        # Mock SemverLock creation
-        mocker.patch(
-            "auto_semver.git.ops.SemverLock.from_dict",
-            side_effect=lambda x: mocker.MagicMock(
-                version=mock_version, target_branch=x["target_branch"]
-            ),
-        )
-
-        # Set up show behavior for lock files
-        def mock_show(path: str) -> str:
-            if "v1.0.0" in path:
-                return "v1.0.0 lock"
-            if "v1.1.0" in path:
-                return "v1.1.0 lock"
-            raise Exception("Not found")
-
-        mock_repo.git.show.side_effect = mock_show
+        mock_semver_lock = mocker.MagicMock(version=mock_version)
+        mocker.patch("auto_semver.git.ops.SemverLock.from_dict", return_value=mock_semver_lock)
 
         # Create GitOps instance
         gitops = GitOps()
 
-        # Call get_highest_release_lock_version_for_target
-        highest_version = gitops.get_highest_release_lock_version_for_target(target_branch="main")
+        # Call get_lock_version_from_branch
+        version = gitops.get_lock_version_from_branch(branch_name="develop")
 
-        # Check results - should have a Version object now
-        assert highest_version is not None
-        assert isinstance(highest_version, Version)
-        mock_remote.fetch.assert_called_once_with(prune=True)
+        # Check results
+        assert version == mock_version
+        mock_repo.git.fetch.assert_called_once_with("origin", "develop")
+        mock_repo.git.show.assert_called_once_with("origin/develop:.semver.lock")

--- a/tests/cli/test_promote.py
+++ b/tests/cli/test_promote.py
@@ -13,7 +13,7 @@ from auto_semver.semver import Version
 class TestPromoteCLI:
     """Tests for the promote CLI command."""
 
-    @patch("auto_semver.git.GitOps.get_highest_release_lock_version_for_target")
+    @patch("auto_semver.git.GitOps.get_lock_version_from_branch")
     @patch("auto_semver.git.GitOps.create_pr")
     def test_successful_promotion(
         self, mock_create_pr: MagicMock, mock_get_version: MagicMock
@@ -25,7 +25,7 @@ class TestPromoteCLI:
 
         # Create mock objects
         gitops = MagicMock(spec=GitOps)
-        gitops.get_highest_release_lock_version_for_target = mock_get_version
+        gitops.get_lock_version_from_branch = mock_get_version
         gitops.create_pr = mock_create_pr
 
         # Mock the config with proper data attribute
@@ -47,7 +47,7 @@ class TestPromoteCLI:
         config.data.validate_promotion.assert_called_once_with(
             from_branch="dev", to_branch="staging", require_auto_promote=False
         )
-        mock_get_version.assert_called_once_with("dev")
+        mock_get_version.assert_called_once_with(branch_name="dev")
         mock_create_pr.assert_called_once()
 
         # Check PR creation parameters (repo_full_name is no longer a parameter)
@@ -78,14 +78,14 @@ class TestPromoteCLI:
                 to_branch="invalid",
             )
 
-    @patch("auto_semver.git.GitOps.get_highest_release_lock_version_for_target")
+    @patch("auto_semver.git.GitOps.get_lock_version_from_branch")
     def test_no_version_found(self, mock_get_version: MagicMock) -> None:
         """Test handling when no version is found for source branch."""
         mock_rule = PromotionRule(from_branch="dev", to_branch="staging")
         mock_get_version.return_value = None
 
         gitops = MagicMock(spec=GitOps)
-        gitops.get_highest_release_lock_version_for_target = mock_get_version
+        gitops.get_lock_version_from_branch = mock_get_version
 
         # Mock the config with proper data attribute
         config = MagicMock(spec=Config)


### PR DESCRIPTION
## 🎯 Summary
Refactor the lock version retrieval logic in `GitOps` to target specific branches instead of scanning all release branches. This fixes potential issues with identifying the correct version during bump and promotion workflows.

## 📋 Changes Made

### Refactoring:
- Replaced `get_highest_release_lock_version_for_target` with `get_lock_version_from_branch` in `GitOps`.
- Updated `bump` and `promote` CLI commands to use the new targeted version check.
- Removed unnecessary scanning of all `origin/release/*` branches.

### Testing:
- Updated unit tests in `test_ops.py`, `test_bump.py`, `test_promote.py`, and `test_bump_promotion.py` to reflect the API changes.
- Verified that `get_lock_version_from_branch` correctly fetches and parses the lockfile from the specified branch.

## 🧪 Testing
- [x] Unit tests updated and passing
- [x] Integration tests pass

## 🔧 Technical Details

### Architecture Changes:
- `GitOps.get_lock_version_from_branch(branch_name)` now fetches only the specified branch and reads `.semver.lock`.
- This improves performance by avoiding a full fetch/scan of all remote refs.
- It ensures that `bump` and `promote` operations use the version explicitly defined in the target/source branch's lockfile.

### Code Diffs:
```diff
-    def get_highest_release_lock_version_for_target(
-        self, target_branch: str | None = None, remote_name: str = "origin"
-    ) -> Version | None:
+    def get_lock_version_from_branch(
+        self,
+        branch_name: str,
+        remote_name: str = "origin",
+    ) -> Version | None:
```

## 📚 Documentation
- [x] Code comments and docstrings updated

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added and passing
- [x] No merge conflicts
- [x] Branch is up-to-date with base branch
