### PR TITLE
Support authenticated HTTPS URLs in repo parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ __pycache__
 
 coverage.xml
 .coverage
+.coverage.*
 htmlcov

--- a/src/auto_semver/git/ops.py
+++ b/src/auto_semver/git/ops.py
@@ -129,7 +129,7 @@ class GitOps:
 
             patterns = [
                 r"git@github\.com:([^/]+)/(.+?)(?:\.git)?$",  # SSH format
-                r"https://github\.com/([^/]+)/(.+?)(?:\.git)?$",  # HTTPS format
+                r"https://(?:.*?@)?github\.com/([^/]+)/(.+?)(?:\.git)?$",  # HTTPS format (supports auth)
             ]
 
             for pattern in patterns:

--- a/tests/auto_semver/git/test_ops_parsing.py
+++ b/tests/auto_semver/git/test_ops_parsing.py
@@ -1,0 +1,77 @@
+"""Tests for GitOps parsing functionality."""
+
+import pytest
+from git import Repo
+from pytest_mock import MockerFixture
+
+from auto_semver.git.ops import GitOps
+
+
+class TestGitOpsParsing:
+    """Test cases for repository parsing in GitOps class."""
+
+    def test_parse_repository_name_ssh(self, mocker: MockerFixture) -> None:
+        """Test parsing of SSH repository URL."""
+        mock_repo = mocker.MagicMock(spec=Repo)
+        mock_remote = mocker.MagicMock()
+        mock_remote.url = "git@github.com:owner/repo.git"
+        mock_repo.remote.return_value = mock_remote
+        mocker.patch("auto_semver.git.ops.Repo", return_value=mock_repo)
+
+        # We need to ensure we don't init the full object which might do other things,
+        # but _parse_repository_name is called in __init__.
+        # So we can just init GitOps.
+
+        # We also need to mock Github auth probably if it happens in init
+        mocker.patch("auto_semver.git.ops.Github")
+
+        ops = GitOps()
+        assert ops._repo_full_name == "owner/repo"
+
+    def test_parse_repository_name_https(self, mocker: MockerFixture) -> None:
+        """Test parsing of HTTPS repository URL."""
+        mock_repo = mocker.MagicMock(spec=Repo)
+        mock_remote = mocker.MagicMock()
+        mock_remote.url = "https://github.com/owner/repo.git"
+        mock_repo.remote.return_value = mock_remote
+        mocker.patch("auto_semver.git.ops.Repo", return_value=mock_repo)
+        mocker.patch("auto_semver.git.ops.Github")
+
+        ops = GitOps()
+        assert ops._repo_full_name == "owner/repo"
+
+    def test_parse_repository_name_https_with_token(self, mocker: MockerFixture) -> None:
+        """Test parsing of HTTPS repository URL with token."""
+        mock_repo = mocker.MagicMock(spec=Repo)
+        mock_remote = mocker.MagicMock()
+        mock_remote.url = "https://x-access-token:token@github.com/owner/repo.git"
+        mock_repo.remote.return_value = mock_remote
+        mocker.patch("auto_semver.git.ops.Repo", return_value=mock_repo)
+        mocker.patch("auto_semver.git.ops.Github")
+
+        ops = GitOps()
+        assert ops._repo_full_name == "owner/repo"
+
+    def test_parse_repository_name_https_with_user_pass(self, mocker: MockerFixture) -> None:
+        """Test parsing of HTTPS repository URL with username and password."""
+        mock_repo = mocker.MagicMock(spec=Repo)
+        mock_remote = mocker.MagicMock()
+        mock_remote.url = "https://user:password@github.com/owner/repo.git"
+        mock_repo.remote.return_value = mock_remote
+        mocker.patch("auto_semver.git.ops.Repo", return_value=mock_repo)
+        mocker.patch("auto_semver.git.ops.Github")
+
+        ops = GitOps()
+        assert ops._repo_full_name == "owner/repo"
+
+    def test_parse_repository_name_failure(self, mocker: MockerFixture) -> None:
+        """Test parsing failure for non-GitHub URL."""
+        mock_repo = mocker.MagicMock(spec=Repo)
+        mock_remote = mocker.MagicMock()
+        mock_remote.url = "https://gitlab.com/owner/repo.git"
+        mock_repo.remote.return_value = mock_remote
+        mocker.patch("auto_semver.git.ops.Repo", return_value=mock_repo)
+        mocker.patch("auto_semver.git.ops.Github")
+
+        with pytest.raises(ValueError, match="Unable to parse GitHub repository"):
+            GitOps()


### PR DESCRIPTION
## 🎯 Summary
Fix repository name parsing for authenticated HTTPS URLs including tokens or credentials.

## 📋 Changes Made

**IMPORTANT: Describe only the changes that are already committed and pushed to the branch. Do NOT add new changes.**

### Bug Fixes:
- Resolve issue where HTTPS URLs with credentials (e.g., `https://token@github.com/...`) failed to parse
- Update regex pattern in `src/auto_semver/git/ops.py` to handle optional authentication section
- Add proper validation for various URL formats

### Testing:
- Add comprehensive test suite `tests/auto_semver/git/test_ops_parsing.py`
- Verify support for SSH, clean HTTPS, and authenticated HTTPS URLs
- Cover edge cases including invalid/non-GitHub URLs

## 🧪 Testing
- [x] Unit tests added/updated
- [x] Integration tests pass
- [ ] Manual testing completed
- [x] Edge cases covered

## 🔧 Technical Details

### Code Diffs (for significant changes):
```diff
- r"https://github\.com/([^/]+)/(.+?)(?:\.git)?$",  # HTTPS format
+ r"https://(?:.*?@)?github\.com/([^/]+)/(.+?)(?:\.git)?$",  # HTTPS format (supports auth)
```

## 📚 Documentation
- [x] Code comments and docstrings updated
- [ ] README updated if needed
- [ ] API documentation updated

## 🔗 Related Issues
- Closes: # (no issue linked in context)

## ✅ Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added and passing
- [x] Documentation updated
- [x] No merge conflicts
- [x] Branch is up-to-date with base branch
