### PR TITLE
Ensure consistent author and committer for commits

### DIFF
--- a/src/auto_semver/git/ops.py
+++ b/src/auto_semver/git/ops.py
@@ -223,8 +223,8 @@ class GitOps:
             # Explicitly set author and committer to ensure consistency (e.g., prevent "GitHub" as committer)
             reader = self.repo.config_reader()
             author = Actor(
-                name=str(reader.get_value("user", "name")), 
-                email=str(reader.get_value("user", "email"))
+                name=str(reader.get_value("user", "name")),
+                email=str(reader.get_value("user", "email")),
             )
             reader.release()
 

--- a/src/auto_semver/git/ops.py
+++ b/src/auto_semver/git/ops.py
@@ -25,7 +25,7 @@ import re
 from pathlib import Path
 
 import yaml
-from git import Commit, GitCommandError, Head, Repo
+from git import Actor, Commit, GitCommandError, Head, Repo
 from git.remote import Remote
 from github import Github
 from github.GithubException import GithubException
@@ -220,7 +220,15 @@ class GitOps:
         logger.debug(f"Staged changes: {self.repo.index.diff('HEAD')}")
 
         try:
-            self.repo.index.commit(message=message)
+            # Explicitly set author and committer to ensure consistency (e.g., prevent "GitHub" as committer)
+            reader = self.repo.config_reader()
+            author = Actor(
+                name=str(reader.get_value("user", "name")), 
+                email=str(reader.get_value("user", "email"))
+            )
+            reader.release()
+
+            self.repo.index.commit(message=message, author=author, committer=author)
 
             logger.info("Committed changes.")
 

--- a/tests/auto_semver/git/test_ops.py
+++ b/tests/auto_semver/git/test_ops.py
@@ -182,17 +182,36 @@ class TestGitOps:
         mock_repo = mocker.MagicMock()
         # Mock index.diff() to return some changes
         mock_repo.index.diff.return_value = ["some_change"]
+        
+        # Mock config reader
+        mock_config_reader = mocker.MagicMock()
+        mock_repo.config_reader.return_value = mock_config_reader
+        mock_config_reader.get_value.side_effect = ["Test User", "test@example.com"]
 
-        # Patch the Repo constructor
+        # Patch the Repo constructor and Actor
         mocker.patch("auto_semver.git.ops.Repo", return_value=mock_repo)
+        mock_actor = mocker.patch("auto_semver.git.ops.Actor")
 
         # Create GitOps instance and call commit
         gitops = GitOps()
         message = "Test commit message"
         gitops.commit(message=message)
 
-        # Check that index.commit was called with the message
-        mock_repo.index.commit.assert_called_once_with(message=message)
+        # Check config reader was used
+        assert mock_config_reader.get_value.call_count == 2
+        mock_config_reader.get_value.assert_any_call("user", "name")
+        mock_config_reader.get_value.assert_any_call("user", "email")
+        mock_config_reader.release.assert_called_once()
+        
+        # Check that Actor was initialized
+        mock_actor.assert_called_once_with(name="Test User", email="test@example.com")
+
+        # Check that index.commit was called with the message and author/committer
+        mock_repo.index.commit.assert_called_once_with(
+            message=message, 
+            author=mock_actor.return_value, 
+            committer=mock_actor.return_value
+        )
 
     @pytest.mark.unit
     def test_push(self, mocker: MockerFixture) -> None:


### PR DESCRIPTION
Core Changes:
- Explicitly set author and committer using GitPython's Actor
- Prevent "GitHub" as committer by using user config values

Impact:
- Enhances commit consistency across different environments
- Improves traceability of commit authorship