### PR TITLE
Update release conditions for GitHub Actions

### DIFF
--- a/.github/actions/gh-release/action.yml
+++ b/.github/actions/gh-release/action.yml
@@ -21,7 +21,7 @@ runs:
         echo "Found tag: $TAG"
         echo "tag=$TAG" >> $GITHUB_OUTPUT
         
-        if [[ "${{ github.ref_name }}" == "staging" ]]; then
+        if [[ "$TAG" == *"-rc"* ]] || [[ "$TAG" == *"-dev"* ]]; then
           echo "is_prerelease=true" >> $GITHUB_OUTPUT
           echo "make_latest=false" >> $GITHUB_OUTPUT
         else

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,13 +3,15 @@ name: Publish Release
 on:
   push:
     tags:
-      - '[0-9*].[0-9*].[0-9*]'
-      - '[0-9*].[0-9*].[0-9*]-rc'
+      - '*.*.*'
+      - '*.*.*-rc'
+      - '!*.*.*-dev'
   workflow_dispatch: #for testing
 
 
 jobs:
   production-release:
+    if: "!contains(github.ref, '-rc')"
     name: Create Release
     runs-on: ubuntu-latest
     permissions:
@@ -22,6 +24,7 @@ jobs:
         uses: ./.github/actions/gh-release
 
   staging-release:
+    if: "contains(github.ref, '-rc')"
     name: Create Release
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Core Changes:
- Modify tag detection logic to identify pre-release tags
- Adjust conditions for setting release flags based on tag type

Impact:
- Ensures correct handling of release types for staging and production
- Improves clarity in release process by distinguishing between release types