### PR TITLE
Remove support for branch strategies

### DIFF
--- a/.github/copilot/instructions/python.instructions.md
+++ b/.github/copilot/instructions/python.instructions.md
@@ -131,7 +131,6 @@ Validation must be automated:
 - Use `GitOps` class for all Git operations - never call git commands directly
 - Always use `GitOps(ensure_safe=True)` in CI environments - marks repo as safe in Git config to avoid permission issues
 - Always use lockfiles (`.semver.lock`) to track release state and prevent version regressions
-- Support both `single` and `multi` branch strategies for different workflow types
 - Handle GitHub API operations through `GitOps._get_github_repo()` method
 - `SemverLock` class prevents race conditions by checking for existing release branches
 
@@ -142,8 +141,6 @@ Validation must be automated:
     dev: "-dev"      # Development releases
     staging: "-rc"   # Release candidates  
     master: ""       # Production releases
-  
-  branch_strategy: "single"  # Controls PR closure behavior
   ```
 - All configuration uses Pydantic v2+ with strict validation
 - Jinja2 templates in config must be validated at load time

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ suffixes:
   staging: "-rc"
   main: ""
 
-branch_strategy: "single"  # "single" or "multi"
-
 files_to_update:
   - "version.txt"
   - "README.md"

--- a/auto_semver_config.yml
+++ b/auto_semver_config.yml
@@ -13,8 +13,6 @@ promotions:
     to_branch: master
     auto_promote: false # Manual promotion only for production
 
-branch_strategy: "single"  # "single" or "multi"
-
 version_files:
   - "version.txt"
   - "pyproject.toml"

--- a/src/auto_semver/cli/bump.py
+++ b/src/auto_semver/cli/bump.py
@@ -162,7 +162,6 @@ def run(*, gitops: GitOps, event: GitHubEvent, config: Config, github_token: str
         VersionFileUpdater(file_path=path, version=version).update()
 
     release_branch_name = f"release/{new_version}"
-    branch_strategy = config.data.branch_strategy
 
     # Update the lockfile with the new version
     try:
@@ -184,22 +183,21 @@ def run(*, gitops: GitOps, event: GitHubEvent, config: Config, github_token: str
     lockfile.target_base_sha = event.get_merged_commit_sha()
     lockfile.save_to_file()
 
-    gitops.create_branch(branch_name=release_branch_name, force=(branch_strategy == "single"))
+    gitops.create_branch(branch_name=release_branch_name, force=True)
     gitops.add(files_to_update)
     gitops.add([lockfile.path])
     gitops.add([changelog.path])
     gitops.commit(f"Release {new_version}")
-    gitops.push(branch_name=release_branch_name, force=(branch_strategy == "single"))
+    gitops.push(branch_name=release_branch_name, force=True)
 
     # Get commits for changelog
 
-    if branch_strategy == "single":
-        logger.info("Closing old release PRs (branch_strategy=single)...")
-        gitops.close_old_release_prs(
-            github_token=github_token,
-            target_branch=target_branch,
-            labels=config.data.pull_request.labels,
-        )
+    logger.info("Closing old release PRs...")
+    gitops.close_old_release_prs(
+        github_token=github_token,
+        target_branch=target_branch,
+        labels=config.data.pull_request.labels,
+    )
 
     release_date = datetime.date.today().strftime("%d-%m-%Y")
 

--- a/src/auto_semver/config/_models/_config.py
+++ b/src/auto_semver/config/_models/_config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal
 
 from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
 

--- a/src/auto_semver/config/_models/_config.py
+++ b/src/auto_semver/config/_models/_config.py
@@ -29,7 +29,6 @@ class ConfigData(BaseModel):
         suffixes (dict[str, str]): Mapping of target branches to version suffixes
             (e.g., {"main": "", "dev": "-dev"}).
         version_files (list[str]): List of files to update with the new version string.
-        branch_strategy (str): Strategy for PR generation ("single" or "multi").
         pull_request (PullRequestConfig): Configuration for the pull request title, body, and labels.
         changelog (_ChangelogConfig): Changelog file behavior and formatting templates.
 
@@ -44,9 +43,6 @@ class ConfigData(BaseModel):
     )
     version_files: list[str] = Field(
         default=["version.txt"], description="Optional files that hold version format to update."
-    )
-    branch_strategy: Literal["single", "multi"] = Field(
-        default="single", description="Strategy for branch management ('single' or 'multi')"
     )
     commit_groups: list[CommitGroupConfig] = Field(
         default_factory=list, description="Optional commit grouping configuration for templates"

--- a/src/auto_semver/config/config.py
+++ b/src/auto_semver/config/config.py
@@ -21,7 +21,7 @@ Typical usage::
 import logging
 import os
 from pathlib import Path
-from typing import Literal, cast
+from typing import cast
 
 import yaml
 from pydantic import ValidationError

--- a/src/auto_semver/config/config.py
+++ b/src/auto_semver/config/config.py
@@ -10,7 +10,6 @@ Typical usage::
     version_files = config.get_files_to_update()
     start_version = config.get_start_version()
     suffix = config.get_suffix("main")
-    branch_strategy = config.get_branch_strategy()
     label = config.get_pr_labels()
     changelog_file = config.get_changelog_file()
     should_truncate_changelog = config.should_truncate_changelog()
@@ -41,7 +40,6 @@ type ConfigValue = (
     | dict[str, str]
     | list[PromotionRule]
     | list[str]
-    | Literal["single", "multi"]
     | list[CommitGroupConfig]
     | PullRequestConfig
     | ChangelogConfig

--- a/tests/auto_semver/cli/test_bump.py
+++ b/tests/auto_semver/cli/test_bump.py
@@ -52,7 +52,6 @@ class TestBump:
         mock.data.suffixes = {"main": "", "develop": "-dev"}
         mock.data.start_version = Version.parse("0.1.0")
         mock.data.version_files = ["version.txt"]
-        mock.data.branch_strategy = "single"
         # Add empty promotions list for tag promotion logic
         mock.data.promotions = []
         # Add empty commit_groups list for commit grouping

--- a/tests/auto_semver/cli/test_bump_promotion.py
+++ b/tests/auto_semver/cli/test_bump_promotion.py
@@ -201,7 +201,6 @@ class TestPromotionWorkflow:
                 PromotionRule(from_branch="staging", to_branch="master"),
             ],
             version_files=["version.txt"],
-            branch_strategy="single",
             commit_groups=[],  # Empty list for minimal setup
             pull_request=PullRequestConfig(
                 title="Release {{version}}", body="Promotion notes", labels=["semver-bump"]

--- a/tests/auto_semver/config/test_data.py
+++ b/tests/auto_semver/config/test_data.py
@@ -195,7 +195,6 @@ class TestConfigData:
             start_version="0.1.0",
             suffixes={"dev": "-dev", "staging": "-rc", "main": ""},
             version_files=["version.txt", "pyproject.toml"],
-            branch_strategy="single",
             promotions=[
                 {"from_branch": "dev", "to_branch": "staging"},
                 {"from_branch": "staging", "to_branch": "main"},
@@ -220,7 +219,6 @@ class TestConfigData:
         assert data.start_version.patch == 0
         assert data.suffixes == {"dev": "-dev", "staging": "-rc", "main": ""}
         assert data.version_files == ["version.txt", "pyproject.toml"]
-        assert data.branch_strategy == "single"
         assert len(data.promotions) == 2
 
     @pytest.mark.unit
@@ -230,7 +228,6 @@ class TestConfigData:
             start_version="0.1.0",
             suffixes={"dev": "-dev", "staging": "-rc", "main": ""},
             version_files=["version.txt"],
-            branch_strategy="multi",
             promotions=[
                 {"from_branch": "dev", "to_branch": "staging"},
                 {"from_branch": "staging", "to_branch": "main"},
@@ -247,22 +244,6 @@ class TestConfigData:
         assert data.promotions[1].to_branch == "main"
 
     @pytest.mark.unit
-    def test_invalid_branch_strategy(self, config_fixture: ConfigFixture) -> None:
-        """Test validation catches invalid branch strategy."""
-        with pytest.raises(ValidationError, match="Input should be 'single' or 'multi'"):
-            config_fixture.create(
-                start_version="0.1.0",
-                suffixes={"dev": "-dev", "staging": "-rc", "main": ""},
-                version_files=["version.txt"],
-                branch_strategy="invalid",  # Invalid strategy
-                promotions=[
-                    {"from_branch": "dev", "to_branch": "staging"},
-                    {"from_branch": "staging", "to_branch": "main"},
-                ],
-            )
-            Config(path=config_fixture.config_path)  # Should fail during validation
-
-    @pytest.mark.unit
     def test_missing_suffix_for_branch(self, config_fixture: ConfigFixture) -> None:
         """Test validation catches branch without defined suffix."""
         with pytest.raises(ValueError, match="missing suffix definitions"):
@@ -270,7 +251,6 @@ class TestConfigData:
                 start_version="0.1.0",
                 suffixes={"dev": "-dev", "staging": "-rc"},  # Missing "main"
                 version_files=["version.txt"],
-                branch_strategy="multi",
                 promotions=[
                     {"from_branch": "dev", "to_branch": "staging"},
                     {"from_branch": "staging", "to_branch": "main"},  # "main" not in suffixes
@@ -286,7 +266,6 @@ class TestConfigData:
                 start_version="0.1.0",
                 suffixes={"dev": "-dev", "staging": "-rc"},
                 version_files=["version.txt"],
-                branch_strategy="multi",
                 promotions=[
                     {"from_branch": "dev", "to_branch": "staging"},
                     {"from_branch": "staging", "to_branch": "dev"},  # Creates a loop!

--- a/tests/auto_semver/config/test_loader.py
+++ b/tests/auto_semver/config/test_loader.py
@@ -24,7 +24,7 @@ class TestConfig:
     def test_config_loading_basic(self, config_fixture: ConfigFixture) -> None:
         """Test basic config loading through Config class."""
         config_fixture.create(
-            start_version="1.0.0", branch_strategy="single", suffixes={"main": "", "dev": "-dev"}
+            start_version="1.0.0", suffixes={"main": "", "dev": "-dev"}
         )
 
         config = Config(config_fixture.config_path)
@@ -33,7 +33,6 @@ class TestConfig:
         assert config.data.start_version.major == 1
         assert config.data.start_version.minor == 0
         assert config.data.start_version.patch == 0
-        assert config.data.branch_strategy == "single"
         assert config.data.suffixes == {"main": "", "dev": "-dev"}
 
     @pytest.mark.unit
@@ -43,7 +42,6 @@ class TestConfig:
         config_file = tmp_path / "custom_config.yml"
         config_file.write_text("""
 start_version: "2.0.0"
-branch_strategy: "multi"
 suffixes:
   main: ""
   dev: "-dev"
@@ -65,7 +63,6 @@ changelog:
 
         # Verify the config was loaded correctly from the custom path
         assert config.data.start_version.major == 2
-        assert config.data.branch_strategy == "multi"
 
     @pytest.mark.unit
     def test_config_missing_file_error(self) -> None:
@@ -91,7 +88,6 @@ changelog:
         incomplete_yaml_file.write_text("""
         # Missing required fields like suffixes and promotions
         start_version: "0.1.0"
-        branch_strategy: "single"
         """)
 
         with pytest.raises(ValueError, match="validation error"):

--- a/tests/auto_semver/config/test_loader.py
+++ b/tests/auto_semver/config/test_loader.py
@@ -23,9 +23,7 @@ class TestConfig:
     @pytest.mark.unit
     def test_config_loading_basic(self, config_fixture: ConfigFixture) -> None:
         """Test basic config loading through Config class."""
-        config_fixture.create(
-            start_version="1.0.0", suffixes={"main": "", "dev": "-dev"}
-        )
+        config_fixture.create(start_version="1.0.0", suffixes={"main": "", "dev": "-dev"})
 
         config = Config(config_fixture.config_path)
 

--- a/tests/auto_semver/git/test_ops.py
+++ b/tests/auto_semver/git/test_ops.py
@@ -182,7 +182,7 @@ class TestGitOps:
         mock_repo = mocker.MagicMock()
         # Mock index.diff() to return some changes
         mock_repo.index.diff.return_value = ["some_change"]
-        
+
         # Mock config reader
         mock_config_reader = mocker.MagicMock()
         mock_repo.config_reader.return_value = mock_config_reader
@@ -202,15 +202,13 @@ class TestGitOps:
         mock_config_reader.get_value.assert_any_call("user", "name")
         mock_config_reader.get_value.assert_any_call("user", "email")
         mock_config_reader.release.assert_called_once()
-        
+
         # Check that Actor was initialized
         mock_actor.assert_called_once_with(name="Test User", email="test@example.com")
 
         # Check that index.commit was called with the message and author/committer
         mock_repo.index.commit.assert_called_once_with(
-            message=message, 
-            author=mock_actor.return_value, 
-            committer=mock_actor.return_value
+            message=message, author=mock_actor.return_value, committer=mock_actor.return_value
         )
 
     @pytest.mark.unit

--- a/tests/integration/test_auto_promotion.py
+++ b/tests/integration/test_auto_promotion.py
@@ -277,7 +277,6 @@ promotions:
     to_branch: master
     auto_promote: false  # Should NOT auto-create PR
 
-branch_strategy: "single"
 version_files: ["version.txt"]
 
 commit_groups:
@@ -398,7 +397,6 @@ promotions:
     to_branch: staging
     auto_promote: true
 
-branch_strategy: "single"
 version_files: ["version.txt"]
 
 commit_groups:


### PR DESCRIPTION
Core Changes:
- Eliminate branch strategy configuration from README and config files
- Refactor bump.py to remove branch strategy logic
- Update tests to reflect removal of branch strategy

Impact:
- Simplifies the configuration and logic for version bumping
- Ensures consistent behavior without branch strategy variations