### PR TITLE
Update promote and publish-release workflows

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -33,6 +33,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Need full history for git operations
+        persist-credentials: false
 
     - name: Get GitHub App Token
       uses: ./.github/actions/app-authentication

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,12 +1,7 @@
 name: Publish Release
 
 on:
-  push:
-    tags:
-      - '*.*.*'
-      - '*.*.*-rc'
-      - '!*.*.*-dev'
-  workflow_dispatch: #for testing
+  deployment
 
 
 jobs:


### PR DESCRIPTION
Core Changes:
- Add 'persist-credentials: false' to promote workflowto make we use the github app token
- Change publish-release trigger from tag push to deployment for streamlined releases