### PR TITLE
fix: pass github token to gh-release action

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -32,3 +32,5 @@ jobs:
 
       - name: GH Release
         uses: ./.github/actions/gh-release
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -30,3 +30,5 @@ jobs:
 
       - name: GH Release
         uses: ./.github/actions/gh-release
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## 🎯 Summary
Pass GitHub token to `gh-release` action to fix HTTP 403 Forbidden errors during release creation.

## 📋 Changes Made

**IMPORTANT: Describe only the changes that are already committed and pushed to the branch. Do NOT add new changes.**

### Bug Fixes:
- Validated `gh-release` permissions failure in CI logs (403 Forbidden).
- Updated `.github/workflows/publish-staging.yml` to explicitly pass `github_token` input to `gh-release` action.
- Updated `.github/workflows/publish-production.yml` to explicitly pass `github_token` input to `gh-release` action.
- Ensured the token comes from the `app-authentication` step (`steps.app-token.outputs.token`).

## 🔧 Technical Details

### Architecture Changes:
- The `gh-release` composite action requires a token with write permissions to create releases.
- Previously, it might have been falling back to default `GITHUB_TOKEN` or failing if no token was provided, resulting in 403.
- By passing the installation token from the GitHub App authentication step, we ensure correct permissions.

### Code Diffs (for significant changes):
```diff
      - name: GH Release
        uses: ./.github/actions/gh-release
+       with:
+         github_token: ${{ steps.app-token.outputs.token }}
```