### PR TITLE
Use CHANGELOG.md for GitHub release notes

### DIFF
--- a/.github/actions/gh-release/action.yml
+++ b/.github/actions/gh-release/action.yml
@@ -24,6 +24,21 @@ runs:
           echo "make_latest=true" >> $GITHUB_OUTPUT
         fi
 
+    - name: Prepare Release Notes
+      shell: bash
+      run: |
+        if [ -f "CHANGELOG.md" ]; then
+          # Extract content starting from the first version header
+          # and stop before the License section if it exists
+          # Use sed to print from the first version header line until the License section or end of file
+          sed -n '/^## \[/,$p' CHANGELOG.md | sed '/^## License/Q' > RELEASE_NOTES.md
+          echo "notes_file=RELEASE_NOTES.md" >> $GITHUB_OUTPUT
+        else
+          echo "CHANGELOG.md not found, falling back to auto-generated notes"
+          echo "notes_file=" >> $GITHUB_OUTPUT
+        fi
+      id: notes
+
     - name: Create GitHub Release
       shell: bash
       env:
@@ -31,9 +46,19 @@ runs:
         TAG: ${{ steps.details.outputs.tag }}
         PRERELEASE: ${{ steps.details.outputs.is_prerelease }}
         LATEST: ${{ steps.details.outputs.make_latest }}
+        NOTES_FILE: ${{ steps.notes.outputs.notes_file }}
       run: |
+        NOTES_ARG=""
+        if [ -n "$NOTES_FILE" ] && [ -f "$NOTES_FILE" ]; then
+          echo "Using release notes from $NOTES_FILE"
+          NOTES_ARG="--notes-file $NOTES_FILE"
+        else
+          echo "Using auto-generated release notes"
+          NOTES_ARG="--generate-notes"
+        fi
+        
         gh release create "$TAG" \
-          --generate-notes \
+          $NOTES_ARG \
           --prerelease="$PRERELEASE" \
           --latest="$LATEST" \
           --title "$TAG"


### PR DESCRIPTION
## 🎯 Summary
Fix release notes generation by using `CHANGELOG.md` instead of GitHub's auto-generated notes, which often fail to correctly identify the previous tag for pre-releases.

## 📋 Changes Made

**IMPORTANT: Describe only the changes that are already committed and pushed to the branch. Do NOT add new changes.**

### [Bug Fixes]:
- Update `.github/actions/gh-release/action.yml` to extract release notes from `CHANGELOG.md`.
- Add logic to parse `CHANGELOG.md` starting from the version header until the license section.
- Fallback to GitHub auto-generated notes only if `CHANGELOG.md` is missing.
- Remove unreliable git tag comparison logic for finding the previous tag.

### [Dependencies]:
- Update `uv.lock` to reflect latest dependency versions.

## 🧪 Testing
- [x] Manual verification of `sed` command for changelog extraction.
- [x] Verified `action.yml` syntax logic.

## 🔧 Technical Details

### Architecture Changes:
- The release workflow now prioritizes the project's curated `CHANGELOG.md` over automated git-diff based notes.
- This ensures that pre-release versions (like `-rc` or `-dev`) get accurate release notes even if git tags are not strictly sequential in a linear history.