### PR TITLE
fix: correct commit message parsing for embedded headers

### DIFF
--- a/src/auto_semver/git/ops.py
+++ b/src/auto_semver/git/ops.py
@@ -478,7 +478,7 @@ class GitOps:
             source_version (str | None): Original version tag from source branch.
             remote_name (str): Remote name (default: 'origin').
             is_source_tag (bool): If True, treat source_branch as a tag.
-            post_merge_hook (Callable[[str, str], None] | None): Optional hook function to execute after merge 
+            post_merge_hook (Callable[[str, str], None] | None): Optional hook function to execute after merge
             but before commit/tag.
             Receives (source_version_str, target_version_str).
 

--- a/src/auto_semver/git/parser.py
+++ b/src/auto_semver/git/parser.py
@@ -44,7 +44,15 @@ class CommitParser:
 
     # Regex for identifying section headers in the body (e.g., "Bug Fixes:")
     # multiline mode is handled by processing line by line
-    _SECTION_HEADER_PATTERN = re.compile(r"^([A-Z][\w\s]+):$")
+    # Supports optional Markdown header prefix (e.g., "### Bug Fixes:")
+    # Logic:
+    # 1. Starts with # -> treated as header (colon optional)
+    # 2. Starts with Capital letter -> must end with colon to be a header
+    _SECTION_HEADER_PATTERN = re.compile(r"^(?:#+\s+(.*?)(?::)?|([A-Z].*?):)\s*$")
+
+    # Regex for finding embedded headers (e.g. "text... ### Header:")
+    # We look for " ## " or " ### " followed by text, to split lines.
+    _EMBEDDED_HEADER_SPLIT = re.compile(r"(\s+)(#{2,}\s+[A-Z].*?)(?:\s|$)")
 
     def parse(self, message: str) -> ParsedCommit:
         """
@@ -83,6 +91,10 @@ class CommitParser:
         sectioned_changes: dict[str, list[str]] = {}
         current_group: str | None = None
 
+        # Pre-process body to split embedded headers onto new lines
+        # This handles cases like: "Added feature. ### Testing:"
+        body = self._EMBEDDED_HEADER_SPLIT.sub(r"\n\2\n", body)
+
         # Split body into lines and process
         lines = body.splitlines()
 
@@ -94,9 +106,19 @@ class CommitParser:
             # Check for section header
             section_match = self._SECTION_HEADER_PATTERN.match(line)
             if section_match:
-                current_group = section_match.group(1).strip()
+                # If group 1 matched (Markdown style), use it.
+                # If group 2 matched (Legacy style without #), use it.
+                header_text = section_match.group(1) or section_match.group(2)
+                current_group = header_text.strip()
                 if current_group not in sectioned_changes:
                     sectioned_changes[current_group] = []
+                continue
+
+            # Check for generic markdown headers (structural break)
+            # If a line starts with '#' but wasn't matched as a section header,
+            # it's a structural break (e.g., "## 🧪 Testing").
+            if line.startswith("#"):
+                current_group = None
                 continue
 
             # Check for list item


### PR DESCRIPTION
## 🎯 Summary
Fix commit message parsing where embedded markdown headers (e.g., `## Testing`) were being treated as text content instead of structural section breaks.

## 📋 Changes Made

### Bug Fixes:
- **Parser Logic**: Added pre-processing step to split lines containing embedded headers (like `...text ### Header`) onto new lines.
- **Regex Update**: Updated `_SECTION_HEADER_PATTERN` to support markdown-style headers (starting with `#`) without requiring a trailing colon.
- **Structure Extraction**: Improved the main loop in `_extract_structure` to correctly switch context when encountering a structural header.

### Testing:
- Verified that headers like `## 🧪 Testing` are now correctly identified as new sections.
- Confirmed that previous parsing logic (standard `Header:` format) remains supported.

## 🧪 Testing
- [x] Regression tests passed.
- [x] Verified fix against the reported issue case.
- [x] Existing functionality verified unaffected.

## 🔧 Technical Details

### Implementation:
- Introduced `_EMBEDDED_HEADER_SPLIT` regex to handle inline header definitions.
- Modified `_SECTION_HEADER_PATTERN` to be more permissible with markdown syntax while maintaining strictness for legacy formats.
